### PR TITLE
fix(security-common): request openid scope for offline JWTs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,5 +104,8 @@ subprojects {
         testImplementation("org.junit.jupiter:junit-jupiter-engine")
         testImplementation("org.junit.jupiter:junit-jupiter-params")
         testImplementation("org.junit.vintage:junit-vintage-engine")
+        // Align the launcher Gradle injects with the junit-bom version; without
+        // this pin test discovery fails with "OutputDirectoryProvider not available".
+        testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     }
 }

--- a/security-common/src/main/kotlin/org/octopusden/cloud/commons/security/client/AuthServerClient.kt
+++ b/security-common/src/main/kotlin/org/octopusden/cloud/commons/security/client/AuthServerClient.kt
@@ -23,7 +23,12 @@ import org.springframework.web.client.RestTemplate
 
 private const val PASSWORD_GRANT_TYPE = "password"
 private const val REFRESH_TOKEN_GRANT_TYPE = "refresh_token"
-private const val OFFLINE_ACCESS_SCOPE = "offline_access"
+// "openid" is mandatory alongside "offline_access": this client's own
+// getUserInfo() hits the OIDC userinfo endpoint, and Keycloak serves userinfo
+// only for tokens carrying the "openid" scope. A token minted without it
+// authenticates fine but then fails authority resolution with 403 on every
+// request to a service protected by this library.
+private const val OFFLINE_JWT_SCOPE = "openid offline_access"
 private val successStatuses = setOf(HttpStatus.OK)
 
 
@@ -76,7 +81,7 @@ class AuthServerClient(
                 add("username", username)
                 add("password", password)
             }
-        }, PASSWORD_GRANT_TYPE, OFFLINE_ACCESS_SCOPE)
+        }, PASSWORD_GRANT_TYPE, OFFLINE_JWT_SCOPE)
     }
 
     fun refreshOfflineJwt(refreshToken: String): OfflineJwt {

--- a/security-common/src/test/kotlin/org/octopusden/cloud/commons/security/client/AuthServerClientTest.kt
+++ b/security-common/src/test/kotlin/org/octopusden/cloud/commons/security/client/AuthServerClientTest.kt
@@ -1,0 +1,102 @@
+package org.octopusden.cloud.commons.security.client
+
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import java.net.URLDecoder
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.octopusden.cloud.commons.security.config.AuthClientProperties
+import org.octopusden.cloud.commons.security.config.AuthServerProperties
+
+/**
+ * Tests for the token requests [AuthServerClient] sends to the auth server,
+ * against a tiny in-process HTTP stub (no Spring context, no network).
+ *
+ * The load-bearing assertion: offline JWTs must be requested with BOTH the
+ * "openid" and "offline_access" scopes. The client's own [AuthServerClient.getUserInfo]
+ * hits the OIDC userinfo endpoint, and Keycloak serves userinfo only for
+ * tokens carrying the "openid" scope — a token minted without it authenticates
+ * fine but then fails authority resolution with 403 on every request.
+ */
+class AuthServerClientTest {
+    private lateinit var server: HttpServer
+    private var capturedTokenRequestBody: String? = null
+
+    @BeforeEach
+    fun startStub() {
+        server = HttpServer.create(InetSocketAddress(0), 0)
+        val base = { "http://localhost:${server.address.port}" }
+        server.createContext("/realms/F1/.well-known/openid-configuration") { exchange ->
+            val body = """
+                {
+                  "token_endpoint": "${base()}/token",
+                  "userinfo_endpoint": "${base()}/userinfo"
+                }
+            """.trimIndent().toByteArray()
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+        server.createContext("/token") { exchange ->
+            capturedTokenRequestBody = exchange.requestBody.readBytes().decodeToString()
+            val body = """
+                {
+                  "access_token": "stub-access",
+                  "refresh_token": "stub-refresh",
+                  "expires_in": 300,
+                  "refresh_expires_in": 0
+                }
+            """.trimIndent().toByteArray()
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+        server.start()
+    }
+
+    @AfterEach
+    fun stopStub() {
+        server.stop(0)
+    }
+
+    private fun client(): AuthServerClient =
+        AuthServerClient(
+            AuthServerProperties(url = "http://localhost:${server.address.port}", realm = "F1"),
+            AuthClientProperties(clientId = "test-client", clientSecret = "test-secret"),
+        )
+
+    private fun capturedParams(): Map<String, List<String>> =
+        capturedTokenRequestBody!!
+            .split("&")
+            .map { it.split("=", limit = 2) }
+            .groupBy({ URLDecoder.decode(it[0], Charsets.UTF_8) }, { URLDecoder.decode(it[1], Charsets.UTF_8) })
+
+    @Test
+    @DisplayName("generateOfflineJwt requests both openid and offline_access scopes")
+    fun `offline jwt scope includes openid`() {
+        val jwt = client().generateOfflineJwt("alice", "secret")
+        assertEquals("stub-access", jwt.accessToken)
+
+        val scopes = capturedParams().getValue("scope").single().split(" ").toSet()
+        assertTrue("offline_access" in scopes) { "offline_access scope missing: $scopes" }
+        assertTrue("openid" in scopes) {
+            "openid scope missing ($scopes): without it Keycloak userinfo returns 403 " +
+                "and getUserInfo-based authority resolution rejects every request"
+        }
+    }
+
+    @Test
+    @DisplayName("generateOfflineJwt sends password grant with client credentials")
+    fun `offline jwt grant shape`() {
+        client().generateOfflineJwt("alice", "secret")
+        val params = capturedParams()
+        assertEquals("password", params.getValue("grant_type").single())
+        assertEquals("alice", params.getValue("username").single())
+        assertEquals("secret", params.getValue("password").single())
+        assertEquals("test-client", params.getValue("client_id").single())
+    }
+}


### PR DESCRIPTION
## Problem

`AuthServerClient.generateOfflineJwt` mints tokens with `scope=offline_access` only, while the same client's `getUserInfo()` resolves authorities via the OIDC **userinfo** endpoint — and Keycloak serves userinfo only for tokens carrying the `openid` scope.

Net effect: every Basic-auth call translated by the api-gateway against a service protected by this library **authenticates fine and then fails with 403** at authority resolution. The library is internally inconsistent — it mints tokens that cannot pass its own userinfo call.

First hit in the wild: components-registry → employee-service person lookups (QA). Currently worked around by adding `openid` as a Default client scope on the gateway's Keycloak client — this PR fixes the root cause for all clients regardless of Keycloak client configuration.

## Change

- `generateOfflineJwt` requests `openid offline_access` (constant renamed to `OFFLINE_JWT_SCOPE` so the name doesn't lie).
- First tests for the module: in-process HTTP stub asserting the token request shape (scope set, grant type, credentials). TDD: scope assertion was red on the old code.
- `org.junit.platform:junit-platform-launcher` pinned to the junit-bom version — without alignment, test discovery fails ("OutputDirectoryProvider not available").

## Compatibility

Additive scope: existing consumers keep `offline_access` (refresh flow untouched — refresh preserves the original scope). Token size grows marginally; userinfo starts working for these tokens, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed test discovery failures by aligning test runtime dependencies.

* **Tests**
  * Added comprehensive test suite for offline token generation and authentication scope handling.

* **Chores**
  * Updated authentication scope configuration to include required offline access parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->